### PR TITLE
Added dotenv package to load environment variables from .env files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.env
 
 # botfiles
 sessions

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@grammyjs/fluent": "^1.0.3",
 		"@grammyjs/storage-file": "^2.0.0",
 		"@moebius/fluent": "^1.1.0",
+		"dotenv": "^16.0.2",
 		"grammy": "^1.10.0",
 		"grammy-inline-menu": "^8.0.0",
 		"telegraf-middleware-console-time": "^2.0.0",

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -1,4 +1,5 @@
 import * as process from 'node:process';
+import { config as envconfig } from 'dotenv'; envconfig();
 
 import {Bot, session} from 'grammy';
 import {FileAdapter} from '@grammyjs/storage-file';


### PR DESCRIPTION
Many people add their environment vars in a `.env` file. In this project, to load `BOT_TOKEN` environment variable from `.env` file I added [dotenv](https://www.npmjs.com/package/dotenv) package.
Dotenv is a zero-dependency module that loads environment variables from a .env file into [process.env](https://nodejs.org/docs/latest/api/process.html#process_process_env).