### PR TITLE
Added dotenv package to load environment variables from .env files. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
+.env
 dist
 node_modules
-.env
 
 # botfiles
 sessions

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.env
 
 # botfiles
 sessions

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"dependencies": {
 		"@grammyjs/i18n": "^1.0.1",
 		"@grammyjs/storage-file": "^2.0.0",
+		"dotenv": "^16.0.2",
 		"grammy": "^1.10.0",
 		"grammy-inline-menu": "^8.0.0",
 		"telegraf-middleware-console-time": "^2.0.0",

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -1,5 +1,5 @@
 import * as process from 'node:process';
-import {config as dotenv} from 'dotenv'; dotenv();
+import {config as dotenv} from 'dotenv';
 
 import {Bot, session} from 'grammy';
 import {FileAdapter} from '@grammyjs/storage-file';
@@ -12,6 +12,7 @@ import {i18n} from '../translation.js';
 import {menu} from './menu/index.js';
 import type {MyContext, Session} from './my-context.js';
 
+dotenv(); // Configure the .env file
 const token = process.env['BOT_TOKEN'];
 if (!token) {
 	throw new Error('You have to provide the bot-token from @BotFather via environment variable (BOT_TOKEN)');

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -1,5 +1,5 @@
 import * as process from 'node:process';
-import { config as envconfig } from 'dotenv'; envconfig();
+import {config as dotenv} from 'dotenv'; dotenv();
 
 import {Bot, session} from 'grammy';
 import {FileAdapter} from '@grammyjs/storage-file';

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -1,4 +1,5 @@
 import * as process from 'node:process';
+import { config as envconfig } from 'dotenv'; envconfig();
 
 import {Bot, session} from 'grammy';
 import {FileAdapter} from '@grammyjs/storage-file';

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -1,8 +1,7 @@
 import * as process from 'node:process';
 
-import {config as dotenv} from 'dotenv';
-
 import {Bot, session} from 'grammy';
+import {config as dotenv} from 'dotenv';
 import {FileAdapter} from '@grammyjs/storage-file';
 import {generateUpdateMiddleware} from 'telegraf-middleware-console-time';
 import {html as format} from 'telegram-format';

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -1,4 +1,5 @@
 import * as process from 'node:process';
+
 import {config as dotenv} from 'dotenv';
 
 import {Bot, session} from 'grammy';

--- a/source/bot/index.ts
+++ b/source/bot/index.ts
@@ -12,7 +12,7 @@ import {i18n} from '../translation.js';
 import {menu} from './menu/index.js';
 import type {MyContext, Session} from './my-context.js';
 
-dotenv(); // Configure the .env file
+dotenv(); // Load from .env file
 const token = process.env['BOT_TOKEN'];
 if (!token) {
 	throw new Error('You have to provide the bot-token from @BotFather via environment variable (BOT_TOKEN)');


### PR DESCRIPTION
Many people add their environment vars in a `.env` file. In this project, to load `BOT_TOKEN` environment variable from `.env` file I added [dotenv](https://www.npmjs.com/package/dotenv) package.
Dotenv is a zero-dependency module that loads environment variables from a .env file into [process.env](https://nodejs.org/docs/latest/api/process.html#process_process_env).